### PR TITLE
Fix Incorrect Path and Suffix Settings in add_executable in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,16 +104,16 @@ ${PROJECT_SOURCE_DIR}/Thirdparty/g2o/lib/libg2o.so
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/Stereo)
 
-add_executable(stereo_kitti execs/stereo_kitti.cc)
+add_executable(stereo_kitti Examples/Stereo/stereo_kitti.cpp)
 target_link_libraries(stereo_kitti ${PROJECT_NAME})
 
-add_executable(stereo_euroc execs/stereo_euroc.cc)
+add_executable(stereo_euroc Examples/Stereo/stereo_euroc.cpp)
 target_link_libraries(stereo_euroc ${PROJECT_NAME})
 
-add_executable(stereo_kaistvio execs/stereo_kaistvio.cc)
+add_executable(stereo_kaistvio Examples/Stereo/stereo_kaistvio.cpp)
 target_link_libraries(stereo_kaistvio ${PROJECT_NAME})
 
-add_executable(stereo_live execs/stereo_live.cpp)
+add_executable(stereo_live Examples/Stereo/stereo_live.cpp)
 target_link_libraries(stereo_live ${PROJECT_NAME})
 
 
@@ -147,5 +147,4 @@ target_link_libraries(mono_kitti ${PROJECT_NAME})
 add_executable(mono_euroc
 Examples/Monocular/mono_euroc.cc)
 target_link_libraries(mono_euroc ${PROJECT_NAME})
-
 


### PR DESCRIPTION
# Description
This PR addresses an issue in the CMakeLists.txt file where the add_executable command was incorrectly configured for both the code path and the suffix. These errors prevented the executable from being properly generated, causing build issues in specific environments.

# Changes
Updated the add_executable path configuration to ensure it points to the correct source files.
Corrected the suffix setting to match the expected output, enabling compatibility with standard builds.
# Testing
Tested on Ubuntu 22.04 LTS to confirm that the changes resolve the build issues without introducing new errors.
Successfully built and ran the project on the above platform.

# Notes
These changes should improve compatibility across various setups and align the build process with expected standards.